### PR TITLE
Fix call to undefined function

### DIFF
--- a/wprp.hm.backup.php
+++ b/wprp.hm.backup.php
@@ -443,11 +443,20 @@ class WPRP_HM_Backup {
     public function get_path() {
 
 		if ( empty( $this->path ) )
-			$this->set_path( self::conform_dir( hmbkp_path_default() ) );
+			$this->set_path( self::conform_dir( self::get_path_default() ) );
 
         return $this->path;
 
     }
+
+	/**
+	 * Get default backup path to save to.
+	 *
+	 * @return string
+	 */
+	protected function get_path_default() {
+		return WP_CONTENT_DIR . '/backups';
+	}
 
 	/**
 	 * Set the directory backups are saved to


### PR DESCRIPTION
This was missed in fe5c879395653136da90d9848386140389f98766 when copying across from the separated hmbkp library.

Fixes #153.